### PR TITLE
Allow symbolic hashes as a raw grammar.

### DIFF
--- a/ruby/lib/tracery.rb
+++ b/ruby/lib/tracery.rb
@@ -527,6 +527,7 @@ class Grammar
     end
     
     def loadFromRawObj(raw)
+        raw = Hash[raw.collect{|k,v| [k.to_s, v]}]
         @raw = raw
         @symbols = {}
         @subgrammars = []

--- a/ruby/lib/version.rb
+++ b/ruby/lib/version.rb
@@ -1,3 +1,3 @@
 module Tracery
-	VERSION = "0.7.5"
+	VERSION = "0.7.6"
 end

--- a/ruby/test/tracery_test.rb
+++ b/ruby/test/tracery_test.rb
@@ -172,4 +172,12 @@ class TraceryTest < Test::Unit::TestCase
         }
     end
 
+    def test_symbolic_hash_grammars
+        grammar = createGrammar({origin: "here's the origin, with an #extra#.", extra: "extra piece of text"})
+        root = grammar.expand("#origin#")
+        all_errors = root.allErrors
+        assert(all_errors.empty?, "No errors should be generated")
+        assert(root.finishedText == "here's the origin, with an extra piece of text.")
+    end
+
 end


### PR DESCRIPTION
Fixes issue #5.
