### PR TITLE
Fix capitalize.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.7.7 - 2016-07-02
+### Fixed
+- [Capitalize downcases everything but first letter](https://github.com/elib/tracery/issues/20)
+
 ## 0.7.6 - 2016-04-29
 ### Added
 - This CHANGELOG.md file

--- a/lib/mods-eng-basic.rb
+++ b/lib/mods-eng-basic.rb
@@ -21,6 +21,15 @@ module Modifiers
             return s + "s"
         end
     end
+
+    def self.capitalize(s)
+        head = s[0]
+        remainder = s[1..-1]
+        return s if(head.nil?)
+        head.upcase!
+        return head if remainder.nil?
+        return head + remainder
+    end
     
     def self.baseEngModifiers
         {
@@ -29,11 +38,11 @@ module Modifiers
             end,
 
             "capitalizeAll" => lambda do |s, parameters|
-                return s.gsub(/\w+/) {|word| word.capitalize}
+                return s.gsub(/\w+/) {|word| capitalize word}
             end,
             
             "capitalize" => lambda do |s, parameters|
-                return s.capitalize
+                return capitalize s
             end,
             
             "a" => lambda do |s, parameters|

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Tracery
-	VERSION = "0.7.6"
+	VERSION = "0.7.7"
 end

--- a/test/tracery_test.rb
+++ b/test/tracery_test.rb
@@ -26,6 +26,10 @@ class TraceryTest < Test::Unit::TestCase
             "monster" => ["dragon", "ogre", "witch", "wizard", "goblin", "golem", "giant", "sphinx", "warlord"],
             "setPronouns" => ["[heroThey:they][heroThem:them][heroTheir:their][heroTheirs:theirs]", "[heroThey:she][heroThem:her][heroTheir:her][heroTheirs:hers]", "[heroThey:he][heroThem:him][heroTheir:his][heroTheirs:his]"],
             "setOccupation" => ["[occupation:baker][didStuff:baked bread,decorated cupcakes,folded dough,made croissants,iced a cake]", "[occupation:warrior][didStuff:fought #monster.a#,saved a village from #monster.a#,battled #monster.a#,defeated #monster.a#]"],
+            "capitalizeMe" => "SOME CAPITAL LETTERS",
+            "capitalizeMore" => "this sentence HAS CAPITALS IN IT",
+            "empty" => "",
+            "single" => "a",
             "origin" => ["#[#setPronouns#][#setOccupation#][hero:#name#]story#"]
         })
         @grammar.addModifiers(Modifiers.baseEngModifiers)
@@ -113,6 +117,31 @@ class TraceryTest < Test::Unit::TestCase
             src: "[pet:#animal#]#nonrecursiveStory# -> #nonrecursiveStory.replace(beach,mall)#"
         },
 
+        modifierCapitalize: {
+            src: "#capitalizeMe.capitalize#",
+            expected: "SOME CAPITAL LETTERS"
+        },
+
+        modifierCapitalizeMore: {
+            src: "#capitalizeMore.capitalize#",
+            expected: "This sentence HAS CAPITALS IN IT"
+        },
+
+        modifierCapitalizeMoreEach: {
+            src: "#capitalizeMore.capitalizeAll#",
+            expected: "This Sentence HAS CAPITALS IN IT"
+        },
+
+        modifierCapitalizeEmpty: {
+            src: "#empty.capitalize#",
+            expected: ""
+        },
+
+        modifierCapitalizeSingle: {
+            src: "#single.capitalize#",
+            expected: "A"
+        },
+
         recursivePush: {
            src: "[pet:#animal#]#recursiveStory#"
         },
@@ -148,7 +177,6 @@ class TraceryTest < Test::Unit::TestCase
         }
         }
 
-        puts
         tests.each { |k,v|
             puts "#{k}: "
             @grammar.clearState
@@ -157,18 +185,19 @@ class TraceryTest < Test::Unit::TestCase
             root = @grammar.expand(source)
             all_errors = root.allErrors
 
-            if(!v[:expected].nil?) then
-                assert(root.finishedText == v[:expected], "\"#{root.finishedText}\" did not match \"#{v[:expected]}\"")
-            else
-                puts "\t#{root.finishedText}"
+            expected = v[:expected]
+
+            if(!expected.nil?) then
+                assert(root.finishedText == expected, "\"#{root.finishedText}\" did not match \"#{expected}\"")
             end
 
             if(is_error) then
-                puts "\tErrors: #{all_errors}"
                 refute(all_errors.empty?, "Expected errors.")
             else
                 assert(all_errors.empty?, "Expected no errors.")
-                refute(root.finishedText.empty?, "Expected non-empty output.")
+                if(!expected.nil? && !expected.empty?) then
+                    refute(root.finishedText.empty?, "Expected non-empty output.")
+                end
             end
         }
     end


### PR DESCRIPTION
Rewrite `capitalize` and `capitalizeAll` to be consistent with original Tracery.
Fixes #20.
